### PR TITLE
Added h2 db config & a basic script to build a docker image and run it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:13-jdk-alpine
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/create_image.sh
+++ b/create_image.sh
@@ -1,0 +1,3 @@
+mvn package
+docker build -t lexisnexis/tms .
+docker run -p 9099:9099 lexisnexis/tms

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-jcl</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 server.port = 9099
+
 spring.datasource.name=tms
 spring.datasource.url=jdbc:mysql://10.143.134.105:3306/tms?serverTimezone=UTC
 spring.datasource.username=root
@@ -7,5 +8,16 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL55Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+#H2
+#spring.jpa.defer-datasource-initialization=true
+#spring.datasource.driverClassName=org.h2.Driver
+#spring.datasource.url=jdbc:h2:mem:testdb
+#spring.datasource.username=sa
+#spring.datasource.password=
+#spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+#spring.jpa.show-sql=true
+
+
 logging.file.name=logback.log
 logging.file.path=/Logs/

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,0 +1,1 @@
+insert into user_details(user_name, first_name, last_name, mobile_no, email, location, password, created_timestamp, last_updated_timestamp) values ('admin', 'user', 'name', '12345', 'user@email.com', 'mumbai', 'password', '2022-04-01', '2023-01-01');

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,0 +1,8 @@
+drop table if exists test CASCADE;
+drop table if exists user_details CASCADE;
+drop table if exists user_login_history CASCADE;
+drop table if exists work_history CASCADE;
+create table test (id bigint not null, label varchar(255), primary key (id));
+create table user_details (user_name varchar(255) not null, created_timestamp timestamp, email varchar(255) not null, first_name varchar(255) not null, last_name varchar(255) not null, last_updated_timestamp timestamp, location varchar(255) not null, mobile_no varchar(255) not null, password varchar(255) not null, primary key (user_name));
+create table user_login_history (user_name varchar(255) not null, failure_attempts integer, is_locked varchar(2), lock_time timestamp, login_status varchar(2), login_time timestamp, primary key (user_name));
+create table work_history (user_name varchar(255) not null, comments varchar(255), created_timestamp timestamp, last_updated_timestamp timestamp, working_area varchar(255), primary key (user_name));


### PR DESCRIPTION
H2 Database is an in memory database, which is simple to configure and can be useful
* a lightweight alternative to persistent db\ can be used when persistent db is not available
* you can populate database with custom data using sql scripts for testing and/or uniformity across different machines running the application locally.
* quickstart tutorial -> https://www.baeldung.com/spring-boot-h2-database

Docker lets you run your applications in containers 
* useful when running multiple services - to automate running the external services you don't need to modify
* script I added is a basic one, for multiple services, we can use docker-compose which allows us to pull and start multiple services at once - can add it in future
* quickstart tutorial -> https://spring.io/guides/gs/spring-boot-docker/